### PR TITLE
Add support for latest version of Redis. Fixes #3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,26 +3,34 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:7afff364b8e5e9f1085fe77ae5630b8e0f7482338a50535881aa0b433e48fb0b"
   name = "github.com/alicebob/gopher-json"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5a6b3ba71ee69b77cf64febf8b5a7526ca5eaef0"
 
 [[projects]]
+  digest = "1:b7cb0201d452c4a7079dc6e8673693c1153b115e906d50d85600c962fc6085a8"
   name = "github.com/alicebob/miniredis"
   packages = [
     ".",
-    "server"
+    "server",
   ]
-  revision = "8890fdcfa933258e09a5b9b897270118064d70fd"
-  version = "2.4.4"
+  pruneopts = "UT"
+  revision = "3657542c8629876a1fa83e0b30a0246a67ffa652"
+  version = "v2.4.5"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:62e9e5a4de4090f87648cbeac5724e07c2f4ce6d2db1db5134ff1f0c182586fd"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -32,55 +40,71 @@
     "internal/pool",
     "internal/proto",
     "internal/singleflight",
-    "internal/util"
+    "internal/util",
   ]
-  revision = "f3bba01df2026fc865f7782948845db9cf44cf23"
-  version = "v6.14.1"
+  pruneopts = "UT"
+  revision = "effc0c507aa2cfe5b7ea45cc8be07de048a19cc3"
+  source = "github.com/go-redis/redis"
 
 [[projects]]
+  digest = "1:38ec74012390146c45af1f92d46e5382b50531247929ff3a685d2b2be65155ac"
   name = "github.com/gomodule/redigo"
   packages = [
     "internal",
-    "redis"
+    "redis",
   ]
+  pruneopts = "UT"
   revision = "9c11da706d9b7902c6da69c592f75637793fe121"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = "UT"
   revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:15a4a7e5afac3cea801fa24831fce3bf3b5bd3620cbf8355a07b7dbf06877883"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock"
+    "mock",
   ]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:8ae7ee611e7317a88b14b088e84e4cd31ac8368d3e95b30668ebd26c33db3275"
   name = "github.com/yuin/gopher-lua"
   packages = [
     ".",
     "ast",
     "parse",
-    "pm"
+    "pm",
   ]
-  revision = "b942cacc89fe49895d145e8b360612a9a51d0423"
+  pruneopts = "UT"
+  revision = "a0dfe84f6227cda1c5f975bf3e35d55ae0d3df61"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4801bab8b609b3e6e52ae60eb59668f6360b42cbcf2542cd19b0c10f768d7a6"
+  input-imports = [
+    "github.com/alicebob/miniredis",
+    "github.com/go-redis/redis",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,8 @@
 
 [[constraint]]
   name = "github.com/go-redis/redis"
-  version = "6.13.2"
+  branch = "master"
+  source = "github.com/go-redis/redis"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/x_cmd.go
+++ b/x_cmd.go
@@ -2,6 +2,14 @@ package redismock
 
 import "github.com/go-redis/redis"
 
+func (m *ClientMock) XDel(stream string, ids ...string) *redis.IntCmd {
+	if !m.hasStub("XDel") {
+		return m.client.XDel(stream, ids...)
+	}
+
+	return m.Called().Get(0).(*redis.IntCmd)
+}
+
 func (m *ClientMock) XAdd(a *redis.XAddArgs) *redis.StringCmd {
 	if !m.hasStub("XAdd") {
 		return m.client.XAdd(a)

--- a/z_cmd.go
+++ b/z_cmd.go
@@ -1,6 +1,26 @@
 package redismock
 
-import "github.com/go-redis/redis"
+import (
+	"time"
+
+	"github.com/go-redis/redis"
+)
+
+func (m *ClientMock) BZPopMax(timeout time.Duration, keys ...string) *redis.ZWithKeyCmd {
+	if !m.hasStub("BZPopMax") {
+		return m.client.BZPopMax(timeout, keys...)
+	}
+
+	return m.Called().Get(0).(*redis.ZWithKeyCmd)
+}
+
+func (m *ClientMock) BZPopMin(timeout time.Duration, keys ...string) *redis.ZWithKeyCmd {
+	if !m.hasStub("BZPopMin") {
+		return m.client.BZPopMin(timeout, keys...)
+	}
+
+	return m.Called().Get(0).(*redis.ZWithKeyCmd)
+}
 
 func (m *ClientMock) ZPopMax(key string, count ...int64) *redis.ZSliceCmd {
 	if !m.hasStub("ZPopMax") {


### PR DESCRIPTION
Changing the source on the `go-redis/redis` package in `Gopkg.toml` was not ideal but I had no choice because the owners of the `go-redis/redis` package have released new methods without tagging a new version.

Fixes #3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/redismock/4)
<!-- Reviewable:end -->
