### PR TITLE
Add support for `ClusterGetKeysInSlot` command

### DIFF
--- a/cmdable.go
+++ b/cmdable.go
@@ -1017,6 +1017,14 @@ func (m *ClientMock) ClusterKeySlot(key string) *redis.IntCmd {
 	return m.Called().Get(0).(*redis.IntCmd)
 }
 
+func (m *ClientMock) ClusterGetKeysInSlot(slot int, count int) *redis.StringSliceCmd {
+	if !m.hasStub("ClusterGetKeysInSlot") {
+		return m.client.ClusterGetKeysInSlot(slot, count)
+	}
+
+	return m.Called().Get(0).(*redis.StringSliceCmd)
+}
+
 func (m *ClientMock) ClusterCountFailureReports(nodeID string) *redis.IntCmd {
 	if !m.hasStub("ClusterCountFailureReports") {
 		return m.client.ClusterCountFailureReports(nodeID)


### PR DESCRIPTION
**What I see:**

```
./token_test.go:92:26: cannot use m (type *redismock.ClientMock) as type redis.Cmdable in field value:
	*redismock.ClientMock does not implement redis.Cmdable (missing ClusterGetKeysInSlot method)
```

**What is changed:**

Add support for latest version of go-redis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/redismock/6)
<!-- Reviewable:end -->
