### PR TITLE
fix: LPosCount returns IntSliceCmd

### DIFF
--- a/v8/cmdable.go
+++ b/v8/cmdable.go
@@ -600,7 +600,7 @@ func (m *ClientMock) LPosCount(ctx context.Context, key string, value string, co
 		return m.client.LPosCount(ctx, key, value, count, args)
 	}
 
-	return m.Called(ctx, key, value, count, args).Get(0).(*redis.IntCmd)
+	return m.Called(ctx, key, value, count, args).Get(0).(*redis.IntSliceCmd)
 }
 
 func (m *ClientMock) LPop(ctx context.Context, key string) *redis.StringCmd {


### PR DESCRIPTION
Update the LPosCount return to match the return type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/redismock/32)
<!-- Reviewable:end -->
