### PR TITLE
fix duplicate key in return value when mocking HSet on v8

### DIFF
--- a/v8/h_cmd.go
+++ b/v8/h_cmd.go
@@ -91,7 +91,7 @@ func (m *ClientMock) HSet(ctx context.Context, key string, values ...interface{}
 		return m.client.HSet(ctx, key, values)
 	}
 
-	return m.Called(ctx, key, key, values).Get(0).(*redis.IntCmd)
+	return m.Called(ctx, key, values).Get(0).(*redis.IntCmd)
 }
 
 func (m *ClientMock) HSetNX(ctx context.Context, key, field string, value interface{}) *redis.BoolCmd {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/redismock/34)
<!-- Reviewable:end -->
